### PR TITLE
use nearest extrapolation when resampling to/from inference resolution

### DIFF
--- a/inference/inference_nnunet.py
+++ b/inference/inference_nnunet.py
@@ -94,7 +94,7 @@ def run_inference_on_file(
         input_nii = [i.reorient(orientation) for i in input_nii]
 
     if zoom is not None:
-        input_nii = [i.rescale_(zoom) for i in input_nii]
+        input_nii = [i.rescale_(zoom, mode="nearest") for i in input_nii]
     input_nii = [squash_so_it_fits_in_float16(i) for i in input_nii]
     if crop:
         crop = input_nii[0].compute_crop(minimum=20)
@@ -103,7 +103,7 @@ def run_inference_on_file(
     if mapping is not None:
         seg_nii.map_labels_(mapping)
     if not keep_size:
-        seg_nii.resample_from_to_(og_nii)
+        seg_nii.resample_from_to_(og_nii, mode="nearest")
     if fill_holes:
         seg_nii.fill_holes_()
     if out_file is not None and (not Path(out_file).exists() or override):


### PR DESCRIPTION
Thanks @robert-graf for making this great work publically available!

This PR fixes the border effect, where the segmentation is 0 along an image border, even though the MRI looks normal and is not background along this border.

Example input resolution:
- dimensions: 320, 320, 290
- spacing: 0.875, 0.875, 0.9

![image](https://github.com/user-attachments/assets/6c709d70-1c10-44bb-911c-7665aa625768)

Note: I guess the issue could also be fixed by modifying the zoom, such that these border effects don't occur.